### PR TITLE
Hide some bottom toolbar actions in certain contexts

### DIFF
--- a/base/src/main/java/com/maubis/scarlet/base/MainActivity.kt
+++ b/base/src/main/java/com/maubis/scarlet/base/MainActivity.kt
@@ -315,6 +315,7 @@ class MainActivity : SecuredActivity(), INoteOptionSheetActivity {
 
   fun notifyFolderChange() {
     val componentContext = ComponentContext(this)
+    setBottomToolbar()
     lithoPreBottomToolbar.removeAllViews()
     if (config.folders.isEmpty()) {
       return
@@ -522,6 +523,7 @@ class MainActivity : SecuredActivity(), INoteOptionSheetActivity {
     lithoBottomToolbar.addView(LithoView.create(componentContext,
         MainActivityBottomBar.create(componentContext)
             .colorConfig(ToolbarColorConfig())
+            .isInsideFolder(config.folders.isNotEmpty())
             .build()))
   }
 

--- a/base/src/main/java/com/maubis/scarlet/base/MainActivity.kt
+++ b/base/src/main/java/com/maubis/scarlet/base/MainActivity.kt
@@ -230,6 +230,7 @@ class MainActivity : SecuredActivity(), INoteOptionSheetActivity {
   private fun notifyModeChange() {
     val isTrash = config.mode === HomeNavigationState.TRASH
     deleteToolbar.visibility = if (isTrash) View.VISIBLE else GONE
+    setBottomToolbar()
   }
 
   /**
@@ -523,6 +524,7 @@ class MainActivity : SecuredActivity(), INoteOptionSheetActivity {
     lithoBottomToolbar.addView(LithoView.create(componentContext,
         MainActivityBottomBar.create(componentContext)
             .colorConfig(ToolbarColorConfig())
+            .hideActions(config.mode == HomeNavigationState.TRASH)
             .isInsideFolder(config.folders.isNotEmpty())
             .build()))
   }

--- a/base/src/main/java/com/maubis/scarlet/base/main/specs/MainActivityBottomBarSpec.kt
+++ b/base/src/main/java/com/maubis/scarlet/base/main/specs/MainActivityBottomBarSpec.kt
@@ -39,6 +39,7 @@ object MainActivityBottomBarSpec {
   @OnCreateLayout
   fun onCreate(context: ComponentContext,
                @Prop colorConfig: ToolbarColorConfig,
+               @Prop hideActions: Boolean,
                @Prop isInsideFolder: Boolean): Component {
     val activity = context.androidContext as MainActivity
     val row = Row.create(context)
@@ -53,33 +54,36 @@ object MainActivityBottomBarSpec {
         })
     row.child(EmptySpec.create(context).heightDip(1f).flexGrow(1f))
 
-    if (!isInsideFolder) {
+    if (!hideActions) {
+      if (!isInsideFolder) {
+        row.child(bottomBarRoundIcon(context, colorConfig)
+            .iconRes(R.drawable.icon_add_notebook)
+            .onClick {
+              CreateOrEditFolderBottomSheet.openSheet(
+                  activity,
+                  FolderBuilder().emptyFolder(sNoteDefaultColor),
+                  { _, _ -> activity.setupData() })
+            })
+      }
+
       row.child(bottomBarRoundIcon(context, colorConfig)
-          .iconRes(R.drawable.icon_add_notebook)
+          .iconRes(R.drawable.icon_add_list)
           .onClick {
-            CreateOrEditFolderBottomSheet.openSheet(
-              activity,
-              FolderBuilder().emptyFolder(sNoteDefaultColor),
-              { _, _ -> activity.setupData() })
+            val intent = CreateNoteActivity.getNewChecklistNoteIntent(
+                activity,
+                activity.config.folders.firstOrNull()?.uuid ?: "")
+            activity.startActivity(intent)
+          })
+      row.child(bottomBarRoundIcon(context, colorConfig)
+          .iconRes(R.drawable.icon_add_note)
+          .onClick {
+            val intent = CreateNoteActivity.getNewNoteIntent(
+                activity,
+                activity.config.folders.firstOrNull()?.uuid ?: "")
+            activity.startActivity(intent)
           })
     }
 
-    row.child(bottomBarRoundIcon(context, colorConfig)
-        .iconRes(R.drawable.icon_add_list)
-        .onClick {
-          val intent = CreateNoteActivity.getNewChecklistNoteIntent(
-              activity,
-              activity.config.folders.firstOrNull()?.uuid ?: "")
-          activity.startActivity(intent)
-        })
-    row.child(bottomBarRoundIcon(context, colorConfig)
-        .iconRes(R.drawable.icon_add_note)
-        .onClick {
-          val intent = CreateNoteActivity.getNewNoteIntent(
-              activity,
-              activity.config.folders.firstOrNull()?.uuid ?: "")
-          activity.startActivity(intent)
-        })
     return bottomBarCard(context, row.build(), colorConfig).build()
   }
 }

--- a/base/src/main/java/com/maubis/scarlet/base/main/specs/MainActivityBottomBarSpec.kt
+++ b/base/src/main/java/com/maubis/scarlet/base/main/specs/MainActivityBottomBarSpec.kt
@@ -38,7 +38,8 @@ import kotlinx.coroutines.launch
 object MainActivityBottomBarSpec {
   @OnCreateLayout
   fun onCreate(context: ComponentContext,
-               @Prop colorConfig: ToolbarColorConfig): Component {
+               @Prop colorConfig: ToolbarColorConfig,
+               @Prop isInsideFolder: Boolean): Component {
     val activity = context.androidContext as MainActivity
     val row = Row.create(context)
         .widthPercent(100f)
@@ -52,14 +53,17 @@ object MainActivityBottomBarSpec {
         })
     row.child(EmptySpec.create(context).heightDip(1f).flexGrow(1f))
 
-    row.child(bottomBarRoundIcon(context, colorConfig)
-        .iconRes(R.drawable.icon_add_notebook)
-        .onClick {
-          CreateOrEditFolderBottomSheet.openSheet(
+    if (!isInsideFolder) {
+      row.child(bottomBarRoundIcon(context, colorConfig)
+          .iconRes(R.drawable.icon_add_notebook)
+          .onClick {
+            CreateOrEditFolderBottomSheet.openSheet(
               activity,
               FolderBuilder().emptyFolder(sNoteDefaultColor),
               { _, _ -> activity.setupData() })
-        })
+          })
+    }
+
     row.child(bottomBarRoundIcon(context, colorConfig)
         .iconRes(R.drawable.icon_add_list)
         .onClick {


### PR DESCRIPTION
I've started to fix some of the inconsistencies mentioned in #121.
With this PR, create folder button is hidden when inside a folder (since nested folders are not possible) and all action buttons (create folder/note) are hidden when displaying deleted notes (trash).
If you're okay with it, I would also move the button for deleting notes permanently (which is currently in the pre-bottom toolbar) to the bottom toolbar, since as it is now it doesn't seem clickable at a first glance and the bottom right corner seems the perfect place for it.