### PR TITLE
Various minor UI fixes and improvements in note preview

### DIFF
--- a/base/src/main/java/com/maubis/scarlet/base/note/formats/recycler/FormatListViewHolder.kt
+++ b/base/src/main/java/com/maubis/scarlet/base/note/formats/recycler/FormatListViewHolder.kt
@@ -42,7 +42,7 @@ class FormatListViewHolder(context: Context, view: View) : FormatTextViewHolder(
       FormatType.CHECKLIST_UNCHECKED -> {
         icon.setImageResource(R.drawable.ic_check_box_outline_blank_white_24dp)
         text.paintFlags = text.paintFlags and Paint.STRIKE_THRU_TEXT_FLAG.inv()
-        itemView.alpha = 0.8f
+        itemView.alpha = 1f
       }
       else -> {
       } // Ignore other cases

--- a/base/src/main/res/layout/item_format_bullet.xml
+++ b/base/src/main/res/layout/item_format_bullet.xml
@@ -16,9 +16,10 @@
 
   <ImageView
     android:id="@+id/icon"
-    android:layout_width="@dimen/icon_size_small"
-    android:layout_height="@dimen/icon_size_small"
-    android:layout_gravity="center_vertical"
+    android:layout_width="8dp"
+    android:layout_height="8dp"
+    android:layout_gravity="top"
+    android:layout_marginTop="@dimen/spacing_normal"
     android:layout_marginStart="@dimen/spacing_large"
     android:src="@drawable/ic_check_box_outline_blank_white_24dp"
     android:tint="@color/material_blue_grey_500" />

--- a/base/src/main/res/layout/item_format_code.xml
+++ b/base/src/main/res/layout/item_format_code.xml
@@ -8,13 +8,13 @@
     android:id="@+id/text"
     style="@style/FormatText"
     android:padding="@dimen/spacing_normal"
-    android:textColor="@color/transparent"
-    android:textColorHint="@color/transparent" />
+    android:paddingStart="@dimen/spacing_small"
+    android:paddingEnd="@dimen/spacing_small" />
 
   <EditText
     android:id="@+id/edit"
     style="@style/FormatText"
     android:padding="@dimen/spacing_normal"
-    android:textColor="@color/transparent"
-    android:textColorHint="@color/transparent" />
+    android:paddingStart="@dimen/spacing_small"
+    android:paddingEnd="@dimen/spacing_small" />
 </LinearLayout>

--- a/base/src/main/res/layout/item_format_list.xml
+++ b/base/src/main/res/layout/item_format_list.xml
@@ -16,12 +16,16 @@
   <TextView
     android:id="@+id/text"
     style="@style/FormatEdit"
+    android:paddingStart="@dimen/spacing_xsmall"
+    android:paddingEnd="@dimen/spacing_xsmall"
     android:autoLink="web"
     android:linksClickable="true" />
 
   <EditText
     android:id="@+id/edit"
-    style="@style/FormatText" />
+    style="@style/FormatText"
+    android:paddingStart="@dimen/spacing_xsmall"
+    android:paddingEnd="@dimen/spacing_xsmall" />
 
   <ImageView
     android:id="@+id/close"

--- a/base/src/main/res/values/styles.xml
+++ b/base/src/main/res/values/styles.xml
@@ -88,8 +88,8 @@
     <item name="android:background">@color/transparent</item>
     <item name="android:lineSpacingExtra">@dimen/extra_text_line_spacing</item>
     <item name="android:paddingTop">@dimen/spacing_xsmall</item>
-    <item name="android:paddingStart">@dimen/spacing_small</item>
-    <item name="android:paddingEnd">@dimen/spacing_small</item>
+    <item name="android:paddingStart">@dimen/spacing_xxsmall</item>
+    <item name="android:paddingEnd">@dimen/spacing_xxsmall</item>
     <item name="android:paddingBottom">@dimen/spacing_xsmall</item>
     <item name="android:layout_marginStart">@dimen/spacing_normal</item>
     <item name="android:layout_marginEnd">@dimen/spacing_normal</item>
@@ -98,8 +98,9 @@
     <item name="android:textSize">@dimen/font_size_normal</item>
   </style>
 
-
   <style name="FormatEdit" parent="FormatText">
+    <item name="android:paddingStart">@dimen/spacing_small</item>
+    <item name="android:paddingEnd">@dimen/spacing_small</item>
     <item name="android:layout_marginStart">@dimen/spacing_xxsmall</item>
     <item name="android:layout_marginEnd">@dimen/spacing_xxsmall</item>
   </style>


### PR DESCRIPTION
This is a rather small PR aimed at fixing some little UI bugs and make some improvements to the note viewer. Changes are the following:
- fix text formats' padding, which was slightly (but visibly) higher than the other paddings
- improve the look of list bullets, which has worsened quite a bit after the latest update. The new look combines the best parts of both the old one (v6.9.5) and the most recent one
- fix the color of checklist formats, which wasn't consistent with all the other formats (it had been set to a different alpha likely by mistake in 712a581)

Here are a screenshot before and one after the PR:
![Screenshot_before](https://user-images.githubusercontent.com/30041551/70849980-ae2eae80-1e85-11ea-82e8-48779fa5cb0d.png)
![Screenshot_after](https://user-images.githubusercontent.com/30041551/70849981-b1299f00-1e85-11ea-950b-e6397a481193.png)
