### PR TITLE
Make note bubble freely positionable

### DIFF
--- a/base/src/main/java/com/maubis/scarlet/base/service/FloatingNoteService.kt
+++ b/base/src/main/java/com/maubis/scarlet/base/service/FloatingNoteService.kt
@@ -27,11 +27,6 @@ import com.maubis.scarlet.base.note.getTitleForSharing
 import com.maubis.scarlet.base.support.ui.ThemeColorType
 import com.maubis.scarlet.base.support.utils.maybeThrow
 
-/**
- * The floating not service
- * Created by bijoy on 3/29/17.
- */
-
 class FloatingNoteService : FloatingBubbleService() {
 
   private var note: Note? = null
@@ -50,7 +45,7 @@ class FloatingNoteService : FloatingBubbleService() {
       .removeBubbleIconDp(72)
       .paddingDp(8)
       .borderRadiusDp(4)
-      .physicsEnabled(true)
+      .physicsEnabled(false)
       .expandableColor(sAppTheme.get(ThemeColorType.BACKGROUND))
       .triangleColor(sAppTheme.get(ThemeColorType.BACKGROUND))
       .gravity(Gravity.END)
@@ -117,7 +112,7 @@ class FloatingNoteService : FloatingBubbleService() {
     return rootView
   }
 
-  fun getShareIntent(note: Note) {
+  private fun getShareIntent(note: Note) {
     val sharingIntent = Intent(Intent.ACTION_SEND)
     sharingIntent.type = "text/plain"
     sharingIntent.putExtra(Intent.EXTRA_SUBJECT, note.getTitleForSharing())
@@ -126,7 +121,7 @@ class FloatingNoteService : FloatingBubbleService() {
     context.startActivity(sharingIntent)
   }
 
-  fun setNote(note: Note) {
+  private fun setNote(note: Note) {
     val noteDescription = Markdown.render(note.getFullTextForDirectMarkdownRender(), true)
     description.text = noteDescription
     timestamp.text = note.getDisplayTime()


### PR DESCRIPTION
This is a small PR to disable note bubble "physics", the feature that constrains the bubble at the walls of the screen.
The motivation behind this modification is that those "physics" behave in an unpredictable way, making the bubble feature almost unusable (see [this video](https://streamable.com/ll7tw)). Futhermore, I can't understand why the user should not be able to position the bubble wherever they want.