### PR TITLE
Hide/disable bottom toolbar actions in certain contexts

### DIFF
--- a/base/src/main/java/com/maubis/scarlet/base/MainActivity.kt
+++ b/base/src/main/java/com/maubis/scarlet/base/MainActivity.kt
@@ -264,6 +264,7 @@ class MainActivity : SecuredActivity(), INoteOptionSheetActivity {
   private fun notifyModeChange() {
     val isTrash = state.mode === HomeNavigationMode.TRASH
     deleteToolbar.visibility = if (isTrash) View.VISIBLE else GONE
+    setBottomToolbar()
   }
 
   fun onFolderChange(folder: Folder?) {
@@ -277,6 +278,7 @@ class MainActivity : SecuredActivity(), INoteOptionSheetActivity {
   private fun notifyFolderChange() {
     val componentContext = ComponentContext(this)
     lithoPreBottomToolbar.removeAllViews()
+    setBottomToolbar()
 
     val currentFolder = state.currentFolder
     if (currentFolder != null) {
@@ -553,6 +555,7 @@ class MainActivity : SecuredActivity(), INoteOptionSheetActivity {
         componentContext,
         MainActivityBottomBar.create(componentContext)
           .colorConfig(ToolbarColorConfig())
+          .disableNewFolderButton(state.currentFolder != null)
           .build()))
   }
 

--- a/base/src/main/java/com/maubis/scarlet/base/MainActivity.kt
+++ b/base/src/main/java/com/maubis/scarlet/base/MainActivity.kt
@@ -173,7 +173,6 @@ class MainActivity : SecuredActivity(), INoteOptionSheetActivity {
 
   fun setListeners() {
     snackbar = MainSnackbar(bottomSnackbar) { loadData() }
-    deleteTrashIcon.setOnClickListener { openDeleteTrashSheet(this@MainActivity) }
     searchBackButton.setOnClickListener {
       onBackPressed()
     }
@@ -263,7 +262,7 @@ class MainActivity : SecuredActivity(), INoteOptionSheetActivity {
 
   private fun notifyModeChange() {
     val isTrash = state.mode === HomeNavigationMode.TRASH
-    deleteToolbar.visibility = if (isTrash) View.VISIBLE else GONE
+    trashNoticeToolbar.visibility = if (isTrash) View.VISIBLE else GONE
     setBottomToolbar()
   }
 
@@ -534,7 +533,6 @@ class MainActivity : SecuredActivity(), INoteOptionSheetActivity {
     containerLayoutMain.setBackgroundColor(getThemeColor())
 
     val toolbarIconColor = sAppTheme.get(ThemeColorType.TOOLBAR_ICON)
-    deleteTrashIcon.setColorFilter(toolbarIconColor)
     deletesAutomatically.setTextColor(toolbarIconColor)
 
     setBottomToolbar()
@@ -556,6 +554,7 @@ class MainActivity : SecuredActivity(), INoteOptionSheetActivity {
         MainActivityBottomBar.create(componentContext)
           .colorConfig(ToolbarColorConfig())
           .disableNewFolderButton(state.currentFolder != null)
+          .isInTrash(state.mode == HomeNavigationMode.TRASH)
           .build()))
   }
 

--- a/base/src/main/java/com/maubis/scarlet/base/main/specs/MainActivityBottomBarSpec.kt
+++ b/base/src/main/java/com/maubis/scarlet/base/main/specs/MainActivityBottomBarSpec.kt
@@ -48,7 +48,9 @@ object MainActivityBottomBarSpec {
   @OnCreateLayout
   fun onCreate(
     context: ComponentContext,
-    @Prop colorConfig: ToolbarColorConfig): Component {
+    @Prop colorConfig: ToolbarColorConfig,
+    @Prop disableNewFolderButton: Boolean
+  ): Component {
     val activity = context.androidContext as MainActivity
     val row = Row.create(context)
       .widthPercent(100f)
@@ -64,6 +66,8 @@ object MainActivityBottomBarSpec {
 
     row.child(bottomBarRoundIcon(context, colorConfig)
                 .iconRes(R.drawable.icon_add_notebook)
+                .alpha(if (disableNewFolderButton) 0.4f else 1.0f)
+                .isClickDisabled(disableNewFolderButton)
                 .onClick {
                   CreateOrEditFolderBottomSheet.openSheet(
                       activity,

--- a/base/src/main/res/layout/toolbar_trash_info.xml
+++ b/base/src/main/res/layout/toolbar_trash_info.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  android:id="@+id/deleteToolbar"
+  android:id="@+id/trashNoticeToolbar"
   style="@style/BorderlessBackgroundView"
   android:layout_width="match_parent"
   android:layout_height="wrap_content"
@@ -18,15 +18,5 @@
     android:text="@string/trash_will_delete_automatically"
     android:textColor="@color/material_blue_grey_700"
     android:textSize="@dimen/font_size_small" />
-
-  <ImageView
-    android:id="@+id/deleteTrashIcon"
-    style="@style/BorderlessBackgroundView"
-    android:layout_width="@dimen/icon_size_xlarge"
-    android:layout_height="@dimen/icon_size_xlarge"
-    android:alpha="0.7"
-    android:padding="@dimen/spacing_small"
-    android:src="@drawable/ic_delete_permanently"
-    android:tint="@color/material_blue_grey_700" />
 
 </LinearLayout>


### PR DESCRIPTION
This PR aims to accomplish what #140 tried to do, with some changes based on the feedback received.
Now the button to create a folder is disabled when inside a folder (and not hidden anymore), while in Trash section all buttons are replaced with a single action to delete permanently all notes (which has been moved down from the trash notice toolbar, since IMHO its intent wasn't clear enough in that place).

Here's a screencast showcasing the changes: https://streamable.com/5i3qe

About the argument of the independence of the toolbar from the content of the screen, which was brought up in the previous PR, here's a quote directly from the [Material Design guidelines](https://material.io/components/app-bars-bottom/#behavior):

> To support the intent of different sections of an app, the layout and actions of a bottom app bar can be changed to suit each screen.

I think this a perfect case where bottom bar actions should change, since none of the other three apply to the context of the trash (and therefore are confusing for the user).